### PR TITLE
Add additional examples and a helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Golang Task Lifecycle Management
 
 [![Go Reference](https://pkg.go.dev/badge/vawter.tech/stopper.svg)](https://pkg.go.dev/vawter.tech/stopper)
+[![codecov](https://codecov.io/gh/bobvawter/go-stopper/graph/badge.svg?token=7XT22QWN4R)](https://codecov.io/gh/bobvawter/go-stopper)
 
 ```shell
 go get vawter.tech/stopper

--- a/signal.go
+++ b/signal.go
@@ -1,0 +1,23 @@
+// Copyright 2025 Bob Vawter (bob@vawter.org)
+// SPDX-License-Identifier: Apache-2.0
+
+package stopper
+
+import (
+	"time"
+)
+
+// StopOnReceive will gracefully stop the Context when a value is received from
+// the channel or if the channel is closed.
+//
+// This can be used, for example, with [os/signal.Notify].
+func StopOnReceive[T any](ctx *Context, gracePeriod time.Duration, ch <-chan T) {
+	ctx.Go(func(ctx *Context) error {
+		select {
+		case <-ch:
+			ctx.Stop(gracePeriod)
+		case <-ctx.Stopping():
+		}
+		return nil
+	})
+}

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Bob Vawter (bob@vawter.org)
+// SPDX-License-Identifier: Apache-2.0
+
+package stopper_test
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"vawter.tech/stopper"
+)
+
+func ExampleStopOnReceive_interrupt() {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt)
+
+	ctx := stopper.WithContext(context.Background())
+	stopper.StopOnReceive(ctx, time.Second, signals)
+
+	ctx.Go(func(ctx *stopper.Context) error {
+		// Do other work
+		return nil
+	})
+
+	if err := ctx.Wait(); err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func TestStopOnReceiveClosed(t *testing.T) {
+	r := require.New(t)
+
+	ctx := stopper.WithContext(context.Background())
+
+	ch := make(chan struct{})
+	close(ch)
+	stopper.StopOnReceive(ctx, time.Second, ch)
+
+	select {
+	case <-ctx.Stopping():
+	case <-time.After(time.Second):
+		r.Fail("did not stop")
+	}
+}
+
+func TestStopOnReceiveStoppedElsewhere(t *testing.T) {
+	r := require.New(t)
+
+	ctx := stopper.WithContext(context.Background())
+
+	ch := make(chan struct{})
+	stopper.StopOnReceive(ctx, time.Second, ch)
+
+	ctx.Go(func(ctx *stopper.Context) error {
+		ctx.Stop(time.Second)
+		return nil
+	})
+
+	select {
+	case <-ctx.Stopping():
+	case <-time.After(time.Second):
+		r.Fail("did not stop")
+	}
+}
+
+func TestStopOnReceiveValue(t *testing.T) {
+	r := require.New(t)
+
+	ctx := stopper.WithContext(context.Background())
+
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+	stopper.StopOnReceive(ctx, time.Second, ch)
+
+	select {
+	case <-ctx.Stopping():
+	case <-time.After(time.Second):
+		r.Fail("did not stop")
+	}
+}


### PR DESCRIPTION
This change adds a helper function that will call Context.Stop when it receives a value from a channel. This can be used, for example, to respond to an os.Interrupt signal.