### PR TITLE
Make retry.Middleware() include pending error on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.0.0
+  * `retry.Middleware` joins the examined error with `Context.Err()` if the context is canceled while waiting.
+
 ## v2.0.0-rc.1
   * `TaskTree` produces stable, human-readable representations of the task hierarchy.
   * `TaskInfo` is now visible to Middleware setup phase.

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -31,7 +31,9 @@ import (
 //
 // If the [stopper.Context.Stopping] channel is closed while waiting for
 // the retry signal, the task will be failed with the previously
-// examined error joined with [stopper.ErrStopped].
+// examined error joined with [stopper.ErrStopped]. Similarly, if
+// [stopper.Context.Done] is closed, the previously examined error will
+// be joined with [stopper.Context.Err].
 //
 // If the returned channel and error are both nil, the error will be
 // considered to have been handled by the Classifier function and the
@@ -80,6 +82,6 @@ func waitOnChannel[N any](ctx stopper.Context, next <-chan N, err error) error {
 	case <-ctx.Stopping():
 		return errors.Join(err, stopper.ErrStopped)
 	case <-ctx.Done():
-		return ctx.Err()
+		return errors.Join(err, ctx.Err())
 	}
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -4,6 +4,7 @@
 package retry
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -86,17 +87,22 @@ func TestContextDone(t *testing.T) {
 		// Return a channel that will never fire.
 		return make(chan struct{}), nil
 	}
+	testCtx := tctx.Context(t)
+	toCancel, cancel := context.WithCancel(testCtx)
+	t.Cleanup(cancel)
 
-	ctx := stopper.WithContext(tctx.Context(t),
+	ctx := stopper.WithContext(toCancel,
 		stopper.WithTaskOptions(stopper.TaskMiddleware(Middleware(classifier))),
 		stopper.WithGracePeriod(time.Millisecond),
 	)
 
+	taskErr := errors.New("task error")
 	err := ctx.Call(func(ctx stopper.Context) error {
-		ctx.Stop()
-		return errors.New("task error")
+		cancel()
+		return taskErr
 	})
-	r.Error(err)
+	r.ErrorIs(err, ctx.Err())
+	r.ErrorIs(err, taskErr)
 }
 
 // TestRetrySuccess verifies that the task is retried when the


### PR DESCRIPTION
This corrects a behavioral mismatch in retry.waitOnChannel() where the pending error would be returned if the context were stopped, but not if the context were canceled.